### PR TITLE
#11 use complete node path for persistent file

### DIFF
--- a/stoptimer-varidelay/stoptimer-varidelay.js
+++ b/stoptimer-varidelay/stoptimer-varidelay.js
@@ -22,13 +22,10 @@ module.exports = function(RED) {
     RED.nodes.createNode(this, n);
     let fs = require('fs');
     let path = require('path');
-    let nodefile = path.join(RED.settings.userDir, "stvd-timers",n.id.toString());
     require('./cycle.js');
     
-    if (n._alias != null) {
-      nodefile = path.join(RED.settings.userDir, "stvd-timers", n.z.toString() + "-" + n._alias.toString());
-    } 
-    const stvdtimersFile = nodefile;    
+    let nodePath = n._flow.path.replace(/\//g, "-");
+    const stvdtimersFile = path.join(RED.settings.userDir, "stvd-timers",nodePath);
 
     this.units = n.units || "Second";
     this.durationType = n.durationType;


### PR DESCRIPTION
Found a solution for #11 
There is a node path in the n._flow object which can be used and is not changed during deploys. Please review.